### PR TITLE
feat: change get tests route

### DIFF
--- a/src/controllers/test/getGroupedByTerm.ts
+++ b/src/controllers/test/getGroupedByTerm.ts
@@ -2,8 +2,8 @@ import { Request, Response } from 'express';
 
 import * as testService from '../../services/test';
 
-export async function getTestsGroupedByTerm(req: Request, res: Response) {
-    const result = await testService.getTestsGroupedByTerm();
+export async function getTestsGroupedByDiscipline(req: Request, res: Response) {
+    const result = await testService.getTestsGroupedByDiscipline();
 
     res.status(200).send(result);
 }

--- a/src/controllers/test/getTests.ts
+++ b/src/controllers/test/getTests.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from 'express';
+
+import * as testService from '../../services/test';
+
+const groupedByList = ['disciplines', 'teachers'];
+
+export async function getTests(req: Request, res: Response) {
+    const { groupedBy } = req.query;
+
+    if (groupedBy && !groupedByList.includes(groupedBy as string)) {
+        return res.status(422).send('Cannot group tests by specified group');
+    }
+
+    if (groupedBy === 'disciplines') {
+        const result = await testService.getTestsGroupedByDiscipline();
+        return res.status(200).send(result);
+    }
+
+    if (groupedBy === 'teachers') {
+        const result = await testService.getTestsGroupedByTeacher();
+        return res.status(200).send(result);
+    }
+
+    const result = await testService.getTests();
+    return res.status(200).send(result);
+}

--- a/src/controllers/test/index.ts
+++ b/src/controllers/test/index.ts
@@ -1,3 +1,2 @@
 export * from './create';
-export * from './getGroupedByTeacher';
-export * from './getGroupedByTerm';
+export * from './getTests';

--- a/src/routes/testRouter.ts
+++ b/src/routes/testRouter.ts
@@ -6,8 +6,6 @@ import { validateSchema, validateToken } from '../middlewares';
 const router = Router();
 
 router.use(validateToken);
-router.route('/').post(validateSchema('newTestSchema'), testController.createTest);
-router.route('/terms').get(testController.getTestsGroupedByTerm);
-router.route('/teachers').get(testController.getTestsGroupedByTeacher);
+router.route('/').post(validateSchema('newTestSchema'), testController.createTest).get(testController.getTests);
 
 export default router;

--- a/src/services/test/testService.ts
+++ b/src/services/test/testService.ts
@@ -20,45 +20,20 @@ export async function createTest(testData: ITestCreateData): Promise<void> {
     await testRepository.insertTest({ name, pdfUrl, categoryId, teacherDisciplineId: relation.id });
 }
 
+export async function getTests() {
+    const tests = await testRepository.findTests();
+
+    return tests;
+}
+
 export async function getTestsGroupedByTeacher() {
     const testsGroupedByTeacher = await testRepository.findTestsGroupedByTeacher();
 
-    const result = testsGroupedByTeacher.map(({ id, categories, ...rest }) => ({
-        ...rest,
-        categories: categories
-            .map(({ tests, ...rest }) => ({
-                ...rest,
-                tests: tests.filter(({ teacherDiscipline: { teacherId, discipline }, ...rest }) => {
-                    if (teacherId === id) {
-                        return { ...rest, discipline };
-                    }
-                }),
-            }))
-            .filter(({ tests }) => tests.length > 0),
-    }));
-
-    return result;
+    return testsGroupedByTeacher;
 }
 
-export async function getTestsGroupedByTerm() {
-    const testsGroupedByTerm = await testRepository.findTestsGroupedByTerm();
+export async function getTestsGroupedByDiscipline() {
+    const testsGroupedByDiscipline = await testRepository.findTestsGroupedByDiscipline();
 
-    const result = testsGroupedByTerm.map(({ disciplines, ...rest }) => ({
-        ...rest,
-        disciplines: disciplines.map(({ id, categories, ...rest }) => ({
-            ...rest,
-            categories: categories
-                .map(({ tests, ...rest }) => ({
-                    ...rest,
-                    tests: tests.filter(({ teacherDiscipline: { disciplineId, teacher }, ...rest }) => {
-                        if (disciplineId === id) {
-                            return { ...rest, teacher };
-                        }
-                    }),
-                }))
-                .filter(({ tests }) => tests.length > 0),
-        })),
-    }));
-
-    return result;
+    return testsGroupedByDiscipline;
 }

--- a/tests/integration/test.test.ts
+++ b/tests/integration/test.test.ts
@@ -103,14 +103,14 @@ describe('/tests', () => {
         });
     });
 
-    describe('GET /tests/terms', () => {
-        describe('given that user is authenticated', () => {
-            it('should return status code 200 and list of tests grouped by terms', async () => {
+    describe('GET /tests', () => {
+        describe('given that user is authenticated and tests is not grouped', () => {
+            it('should return status code 200 and list of tests with its details', async () => {
                 const newUser = createUser();
                 const insertedUser = await insertUser(newUser);
                 const token = generateToken({ id: insertedUser.id });
 
-                const result = await agent.get('/tests/terms').set({ Authorization: `Bearer ${token}` });
+                const result = await agent.get('/tests').set({ Authorization: `Bearer ${token}` });
                 expect(result.status).toBe(200);
                 expect(Array.isArray(result.body)).toBe(true);
             });
@@ -122,33 +122,36 @@ describe('/tests', () => {
                 const insertedUser = await insertUser(newUser);
                 const token = generateToken({ id: insertedUser.id + 1 });
 
-                const result = await agent.get('/tests/terms').set({ Authorization: `Bearer ${token}` });
+                const result = await agent.get('/tests').set({ Authorization: `Bearer ${token}` });
                 expect(result.status).toBe(401);
             });
         });
     });
 
-    describe('GET /tests/teachers', () => {
+    describe('GET /tests?groupedBy=disciplines', () => {
+        describe('given that user is authenticated', () => {
+            it('should return status code 200 and list of tests grouped by disciplines', async () => {
+                const newUser = createUser();
+                const insertedUser = await insertUser(newUser);
+                const token = generateToken({ id: insertedUser.id });
+
+                const result = await agent.get('/tests?groupedBy=disciplines').set({ Authorization: `Bearer ${token}` });
+                expect(result.status).toBe(200);
+                expect(Array.isArray(result.body)).toBe(true);
+            });
+        });
+    });
+
+    describe('GET /tests?groupedBy=teachers', () => {
         describe('given that user is authenticated', () => {
             it('should return status code 200 and list of tests grouped by teachers', async () => {
                 const newUser = createUser();
                 const insertedUser = await insertUser(newUser);
                 const token = generateToken({ id: insertedUser.id });
 
-                const result = await agent.get('/tests/teachers').set({ Authorization: `Bearer ${token}` });
+                const result = await agent.get('/tests?groupedBy=teachers').set({ Authorization: `Bearer ${token}` });
                 expect(result.status).toBe(200);
                 expect(Array.isArray(result.body)).toBe(true);
-            });
-        });
-
-        describe('given that token is invalid', () => {
-            it('should return status code 401', async () => {
-                const newUser = createUser();
-                const insertedUser = await insertUser(newUser);
-                const token = generateToken({ id: insertedUser.id + 1 });
-
-                const result = await agent.get('/tests/teachers').set({ Authorization: `Bearer ${token}` });
-                expect(result.status).toBe(401);
             });
         });
     });


### PR DESCRIPTION
- 'groupedBy' query string must be sent to group tests by teachers or disicplines
- if 'groupedBy' is not sent, it will return a list with all tests and its details